### PR TITLE
Add telefone_celular field to Paciente model

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -42,11 +42,14 @@ class CadastrarPacienteForm(forms.ModelForm):
     def clean_telefone_celular(self):
         val = self.cleaned_data.get("telefone_celular", "") or ""
         import re
+
         digits = re.sub(r"\D+", "", val)[:11]  # só dígitos, no máx 11
         # opcional: exigir 11 dígitos começando com 9 no 3º
         if digits and not (len(digits) == 11 and digits[2] == "9"):
-            raise forms.ValidationError("Informe um celular válido com DDD e 9 dígitos.")
-        return digits  
+            raise forms.ValidationError(
+                "Informe um celular válido com DDD e 9 dígitos."
+            )
+        return digits
 
     class Meta:
         model = Paciente

--- a/core/migrations/0003_paciente_telefone_celular.py
+++ b/core/migrations/0003_paciente_telefone_celular.py
@@ -7,13 +7,25 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0002_rename_consulta_chamadaprofissional_customuser_sala_and_more'),
+        ("core", "0002_rename_consulta_chamadaprofissional_customuser_sala_and_more"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='paciente',
-            name='telefone_celular',
-            field=models.CharField(blank=True, help_text='Ex.: (99) 9 9999-9999', max_length=20, null=True, validators=[django.core.validators.RegexValidator(message='Informe um celular válido(DDD + 9 dígitos, ex.: (99) 9 9999-9999).', regex='^\\D*?(\\d{2})\\D*?(9\\d{4})\\D*?(\\d{4})\\D*$')], verbose_name='Telefone celular (com DDD)'),
+            model_name="paciente",
+            name="telefone_celular",
+            field=models.CharField(
+                blank=True,
+                help_text="Ex.: (99) 9 9999-9999",
+                max_length=20,
+                null=True,
+                validators=[
+                    django.core.validators.RegexValidator(
+                        message="Informe um celular válido(DDD + 9 dígitos, ex.: (99) 9 9999-9999).",
+                        regex="^\\D*?(\\d{2})\\D*?(9\\d{4})\\D*?(\\d{4})\\D*$",
+                    )
+                ],
+                verbose_name="Telefone celular (com DDD)",
+            ),
         ),
     ]

--- a/core/models.py
+++ b/core/models.py
@@ -95,29 +95,30 @@ class Paciente(models.Model):
         help_text="Ex.: (99) 9 9999-9999",
         validators=[
             RegexValidator(
-                regex=r'^\D*?(\d{2})\D*?(9\d{4})\D*?(\d{4})\D*$',
-                message="Informe um celular válido(DDD + 9 dígitos, ex.: (99) 9 9999-9999)."
+                regex=r"^\D*?(\d{2})\D*?(9\d{4})\D*?(\d{4})\D*$",
+                message="Informe um celular válido(DDD + 9 dígitos, ex.: (99) 9 9999-9999).",
             )
         ],
     )
 
     def telefone_e164(self) -> str | None:
-        
-        #Retorna o telefone em formato E.164 (+55DDDNXXXXXXXX) ou None se não houver.
-        #Aceita formatos variados e converte para +55.
-        
+
+        # Retorna o telefone em formato E.164 (+55DDDNXXXXXXXX) ou None se não houver.
+        # Aceita formatos variados e converte para +55.
+
         if not self.telefone_celular:
             return None
         import re
-        digits = re.sub(r'\D+', '', self.telefone_celular)  
+
+        digits = re.sub(r"\D+", "", self.telefone_celular)
         # Esperado: 2 (DDD) + 9 (celular iniciando em 9) = 11 dígitos
-        if len(digits) == 11 and digits[2] == '9':
+        if len(digits) == 11 and digits[2] == "9":
             return f"+55{digits}"
         # Caso venha já com 13 (+55) -> remove prefixos e tenta padronizar
-        if len(digits) == 13 and digits.startswith('55') and digits[4] == '9':
+        if len(digits) == 13 and digits.startswith("55") and digits[4] == "9":
             return f"+{digits}"
         return None  # inválido
-    
+
     observacoes = models.CharField(
         max_length=255, blank=True, null=True, verbose_name="Observações"
     )


### PR DESCRIPTION
Introduces a new 'telefone_celular' field to the Paciente model with validation for Brazilian mobile numbers. Adds a migration for the new field, a form field validator, and a helper method to return the number in E.164 format.